### PR TITLE
Fix typos in German translation

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -8,8 +8,8 @@
 	  },
 	  "settings": {
 		  "doorControlSizeFactor": {
-			  "name": "Sklaierungsfaktor des Türsymbols",
-			  "hint": "Legt fest um welchen faktor die Größe der Türsymbole hochskaliert werden sollen"
+			  "name": "Skalierungsfaktor des Türsymbols",
+			  "hint": "Legt fest um welchen Faktor die Größe der Türsymbole hochskaliert werden sollen"
 		  },
 		  "highlightSecretDoors": {
 			  "name": "Geheimtüren einfärben",
@@ -27,12 +27,12 @@
 	  "ui": {
 		  "lockedDoorAlert": "Hat versucht eine verschlossene Tür zu öffnen",
 		  "messages": {
-			  "migrating": "Update Smart Doors zur Version {version}. Bitte schließe die Anwendung nicht.",
-			  "migrationDone": "Smart Doors wurde erfolgreich auf die Version {version} geupdated.",
-			  "unknownVersion": "Das Update von Smart doors ist mit folgendem Fehler fehlgeschlagen: Unbekannte Version {version}. Bite melde diesen Fehler im Bugtracker von Smart Doors. Um Datenverlust zu vermeiden, dekativiere dieses Modul bis dieser Fehler behoben ist."
+			  "migrating": "Aktualisiere Smart Doors zur Version {version}. Bitte schließe die Anwendung nicht!",
+			  "migrationDone": "Smart Doors wurde erfolgreich auf die Version {version} aktualisiert.",
+			  "unknownVersion": "Die Aktualisierung von Smart Doors ist mit folgendem Fehler fehlgeschlagen: Unbekannte Version {version}. Bite melde diesen Fehler im Bugtracker von Smart Doors. Um Datenverlust zu vermeiden, deaktiviere dieses Modul, bis dieser Fehler behoben ist."
 		  },
 		  "synchronizedDoors": {
-			  "description": "Zustandsänderungen von Türen in der gleichen Synchronisationsgruppe werden Szenenübergreifend synchronisiert. Lasse dieses Feld leer, wenn du diese Tür nicht Synchornisieren möchtest.",
+			  "description": "Zustandsänderungen von Türen in der gleichen Synchronisationsgruppe werden szenenübergreifend synchronisiert. Lasse dieses Feld leer, wenn du diese Tür nicht synchronisieren möchtest.",
 			  "groupName": "Synchronisationsgruppe",
 			  "synchronizeSecretStatus": "Geheimtürstatus synchronisieren"
 		  }


### PR DESCRIPTION
Some fixes (mostly typos) to the German translation. 