### PR TITLE
Fixes wrong object datapath for door sync groups

### DIFF
--- a/src/features/synchronized_doors.js
+++ b/src/features/synchronized_doors.js
@@ -22,7 +22,7 @@ export function onRederWallConfig(wallConfig, html, data) {
 		`;
 		html.find(".form-group").last().after(synchronizedSettings);
 
-		const smartdoorsData = data.object.flags.smartdoors;
+		const smartdoorsData = data.document.flags.smartdoors;
 		// Fill the injected input fields with values
 		const input = name => html.find(`input[name="${name}"]`); // input is a helper function to search for a input field by it's name
 		input("synchronizationGroup").prop("value", smartdoorsData?.synchronizationGroup);


### PR DESCRIPTION
Fixes a wrong object datapath access to the flags array where the door sync group name is stored. After this fix, you can enter labels for door sync groups and synced doors start working again